### PR TITLE
Fix: Job Chain Creation Pattern with await FastJobServer.CreateChain(…

### DIFF
--- a/FastJobs.Core/Data/Dtos/FastJobConstants.cs
+++ b/FastJobs.Core/Data/Dtos/FastJobConstants.cs
@@ -6,14 +6,6 @@ public static class FastJobConstants
     public static string DefaultQueue = "Default";
 }
 
-//REPEATED IN FASTJOBS.SQLSERVER
-public static class JobTypes
-{
-    public static string Enqueued = "Enqueued";
-    public static string Scheduled = "Scheduled";
-    public static string Recurring = "Recurring";
-    public static string ChainHead = "Chain";
-}
 
 public enum JobPriority
 {

--- a/FastJobs.Core/Services/ChainBuilder.cs
+++ b/FastJobs.Core/Services/ChainBuilder.cs
@@ -1,5 +1,6 @@
 // ── ChainJobBuilder ───────────────────────────────────────────────────────────
 
+using System.Linq.Expressions;
 using System.Text.Json;
 using Fastjobs.AfterActions;
 using FastJobs;
@@ -16,10 +17,18 @@ public class ChainJobBuilder
         _scopeFactory = scopeFactory;
     }
 
-    // Called by ChainStepOptions to keep ThenRun chains working
-    internal ChainStepOptions AddStep<TJob>() where TJob : class, IBackGroundJob
+    // Called by ChainStepOptions to keep ThenRun chains working And on First Addition 
+    public ChainStepOptions AddStep<TJob>() where TJob : class, IBackGroundJob
     {
         var job = FastJobServer.CreateJobTemplate<TJob>();
+        job.JobType = JobTypes.ChainHead;
+        _steps.Add(job);
+        return new ChainStepOptions(job, this);
+    }
+
+    public ChainStepOptions AddStep(Expression<Action> actionExpression)
+    {
+        var job = FastJobServer.CreateJobTemplate(actionExpression);
         _steps.Add(job);
         return new ChainStepOptions(job, this);
     }

--- a/FastJobs.Core/Services/ChainStepOptions.cs
+++ b/FastJobs.Core/Services/ChainStepOptions.cs
@@ -2,6 +2,7 @@
 // Mirrors EnqueueOptions but owns one chain step and delegates chain
 // continuation back to the builder
 
+using System.Linq.Expressions;
 using FastJobs;
 using FastJobs.SqlServer;
 
@@ -37,6 +38,9 @@ public class ChainStepOptions
     // Returns a new ChainStepOptions for the next step — builder owns the list
     public ChainStepOptions ThenRun<TJob>() where TJob : class, IBackGroundJob =>
         _builder.AddStep<TJob>();
+
+    public ChainStepOptions ThenRunExpression(Expression<Action> actionExpression) => 
+        _builder.AddStep(actionExpression);
 
     public Task EnqueueAsync(CancellationToken cancellationToken = default) =>
         _builder.EnqueueAsync(cancellationToken);

--- a/FastJobs.Core/Services/ChainStepOptions.cs
+++ b/FastJobs.Core/Services/ChainStepOptions.cs
@@ -39,7 +39,7 @@ public class ChainStepOptions
     public ChainStepOptions ThenRun<TJob>() where TJob : class, IBackGroundJob =>
         _builder.AddStep<TJob>();
 
-    public ChainStepOptions ThenRunExpression(Expression<Action> actionExpression) => 
+    public ChainStepOptions ThenRun(Expression<Action> actionExpression) => 
         _builder.AddStep(actionExpression);
 
     public Task EnqueueAsync(CancellationToken cancellationToken = default) =>

--- a/FastJobs.Core/Services/FastJobServer.cs
+++ b/FastJobs.Core/Services/FastJobServer.cs
@@ -125,15 +125,21 @@ public static class FastJobServer
 
 
     // ── Chained  ─────────────────────────────────────────────────────────────────
-    public static ChainStepOptions CreateChain<TJob>() where TJob : class, IBackGroundJob {
+
+    public static ChainJobBuilder CreateChain() {
+        return  new ChainJobBuilder(_ScopeFactory);
+    }
+
+ /*   public static ChainStepOptions CreateChain<TJob>() where TJob : class, IBackGroundJob {
         var job = CreateJobTemplate<TJob>();
         return new ChainStepOptions(job,  new ChainJobBuilder(_ScopeFactory));
     }
+    */
 
-    public static ChainStepOptions CreateChain(Expression<Action> actionExpression) 
+   /* public static ChainStepOptions CreateChain(Expression<Action> actionExpression) 
     {
         var job = CreateJobTemplate(actionExpression);
         return new ChainStepOptions(job,  new ChainJobBuilder(_ScopeFactory));
-    }
+    } */
 
 }

--- a/FastJobs.SqlServer/Data/Job.cs
+++ b/FastJobs.SqlServer/Data/Job.cs
@@ -6,7 +6,7 @@ public static class JobTypes
     public static string Enqueued = "Enqueued";
     public static string Scheduled = "Scheduled";
     public static string Recurring = "Recurring";
-    public static string Batch = "Batch";
+    public static string ChainHead = "Chain";
 }
 
 

--- a/Test/Program.cs
+++ b/Test/Program.cs
@@ -33,8 +33,8 @@ app.Services.UseFastJobs();
 await app.StartAsync();
 
 
-await FastJobServer.CreateChain<ValidateOrderJob>()
-.ThenRun<ValidateOrderJob>()
+await FastJobServer.CreateChain()
+.AddStep<ValidateOrderJob>()
 .ThenRun<ChargePaymentJob>()
 .ThenRun<SendConfirmationEmailJob>()
 .ThenRun<NotifyWarehouseJob>()


### PR DESCRIPTION
Final Solution Resulted In Usage That Works Like 
await FastJobServer.CreateChain()
.AddStep<ValidateOrderJob>()
.ThenRun<ChargePaymentJob>()
.ThenRun<SendConfirmationEmailJob>()
.ThenRun<NotifyWarehouseJob>()
.EnqueueAsync();

And Addition For Expression Jobs 

await FastJobServer.CreateChain()
.AddStep(() => ValidateOrderJob.Run() )
.ThenRun<ChargePaymentJob>()
.ThenRun(() => SendConfirmationEmailJob.run())
.ThenRun<NotifyWarehouseJob>()
.EnqueueAsync();

Resolves #8 
