### PR TITLE
 fix: correct job state transitions on termination and retry exhaustion

### DIFF
--- a/Tests/Integration/Fastjobs.AfterAction/AfterAction.csproj
+++ b/Tests/Integration/Fastjobs.AfterAction/AfterAction.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DBHostFixtureProviders\DBHostFixtureProvider.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Integration/Fastjobs.AfterAction/HostFixture.cs
+++ b/Tests/Integration/Fastjobs.AfterAction/HostFixture.cs
@@ -1,0 +1,22 @@
+
+
+using FastJobs;
+using FastJobs.Persistence;
+using HostFixtureProviders;
+using Microsoft.Extensions.DependencyInjection;
+
+public class TerminateJobTestFixture : FastJobsHostFixtureBase
+{
+    public TerminateJobTestFixture() : base(new MariaDBFixture()) { }
+
+    protected override void ConfigureFastJobs(IServiceCollection services, string connectionString)
+    {
+        services.AddJobService<DeleteAfterActionTestJob>();
+        services.AddFastJobs(o => o.WorkerCount = 1,
+            new FastJobMysqlDependencies(x =>
+            {
+                x.ConnectionString = connectionString;
+                x.SchemaName = "FastjobsDB";
+            }));
+    }
+}

--- a/Tests/Integration/Fastjobs.AfterAction/Job.cs
+++ b/Tests/Integration/Fastjobs.AfterAction/Job.cs
@@ -1,0 +1,18 @@
+using FastJobs;
+using Microsoft.Extensions.Logging;
+
+public class DeleteAfterActionTestJob : IBackGroundJob
+{
+    private readonly ILogger<DeleteAfterActionTestJob> _logger;
+
+    public DeleteAfterActionTestJob(ILogger<DeleteAfterActionTestJob> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("[{Thread}] Delete After Action Test Job Simply Doing it Thing ", Thread.CurrentThread.Name);
+        _logger.LogInformation("[{Thread}] Job Should Be Deleted After This ", Thread.CurrentThread.Name);
+    }
+}

--- a/Tests/Integration/Fastjobs.AfterAction/Test.cs
+++ b/Tests/Integration/Fastjobs.AfterAction/Test.cs
@@ -39,7 +39,7 @@ public class AfterActionTest : IClassFixture<AfterActionJobTestFixture>
     }
 
     [Fact]
-    public async Task Job_Throwing_TerminateJobException_Should_Be_Deleted_By_AfterAction()
+    public async Task Job_Should_Be_Completed_And_Then_Deleted_By_AfterAction()
     {
         // Arrange
         var since = DateTime.UtcNow;

--- a/Tests/Integration/Fastjobs.AfterAction/Test.cs
+++ b/Tests/Integration/Fastjobs.AfterAction/Test.cs
@@ -1,0 +1,69 @@
+using FastJobs;
+using FastJobs.AfterActions;
+using FastJobs.Dashboard.Models;
+using FastJobs.Persistence;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+[CollectionDefinition("FastJobServerTests")]
+public class ServerCollectionDefinition { }
+
+[Collection("FastJobServerTests")]
+public class TerminateExceptionJobTests : IClassFixture<TerminateJobTestFixture>
+{
+    private readonly TerminateJobTestFixture _fixture;
+    private readonly ITestOutputHelper _output;
+    private readonly IJobRepository _repo;
+
+    public TerminateExceptionJobTests(TerminateJobTestFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _repo = fixture.Host.Services.GetService<IJobRepository>();
+        _output = output;
+    }
+
+    private static async Task WaitUntilAsync(
+        Func<Task<int>> condition,
+        int expected,
+        TimeSpan timeout)
+    {
+        var start = DateTime.UtcNow;
+        var actual = 0;
+        while (DateTime.UtcNow - start < timeout)
+        {
+            actual = await condition();
+            if (actual == expected)
+                return;
+
+            await Task.Delay(100); // poll interval
+        }
+    }
+
+    [Fact]
+    public async Task Job_Throwing_TerminateJobException_Should_Be_Deleted_By_AfterAction()
+    {
+        // Arrange
+        var since = DateTime.UtcNow;
+
+        // Act
+        await FastJobServer.EnqueueJob<DeleteAfterActionTestJob>()
+            .AddAfterAction(x => x.WithType<DeleteAfterAction>())
+            .Start();
+
+        await WaitUntilAsync(
+            condition: async () => (await _repo.GetAllAsync()).Count,
+            expected: 0,
+            timeout: TimeSpan.FromSeconds(50));
+
+        var allEntries = await _repo.GetAllAsync();
+
+        foreach (var e in allEntries)
+        {
+            _output.WriteLine($"Name: {e.TypeName} state: {e.StateName}");
+        }
+
+        // Assert
+        var All = await _repo.GetAllAsync();
+        var count = All.Count;
+        Assert.Equal(0, count);
+    }
+}

--- a/Tests/Integration/Fastjobs.FailedJobsTest/FailjobsTest.csproj
+++ b/Tests/Integration/Fastjobs.FailedJobsTest/FailjobsTest.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DBHostFixtureProviders\DBHostFixtureProvider.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Integration/Fastjobs.FailedJobsTest/HostFixture.cs
+++ b/Tests/Integration/Fastjobs.FailedJobsTest/HostFixture.cs
@@ -5,14 +5,14 @@ using FastJobs.Persistence;
 using HostFixtureProviders;
 using Microsoft.Extensions.DependencyInjection;
 
-public class AfterActionJobTestFixture : FastJobsHostFixtureBase
+public class FailedJobFixtureTest : FastJobsHostFixtureBase
 {
-    public AfterActionJobTestFixture() : base(new MariaDBFixture()) { }
+    public FailedJobFixtureTest() : base(new MariaDBFixture()) { }
 
     protected override void ConfigureFastJobs(IServiceCollection services, string connectionString)
     {
-        services.AddJobService<DeleteAfterActionTestJob>();
-        services.AddFastJobs(o => o.WorkerCount = 1,
+        services.AddJobService<FailJob>();
+        services.AddFastJobs(o => { o.WorkerCount = 1; o.Jitter = TimeSpan.FromSeconds(2); o.JobRetryDelayBase = TimeSpan.FromSeconds(5); },
             new FastJobMysqlDependencies(x =>
             {
                 x.ConnectionString = connectionString;

--- a/Tests/Integration/Fastjobs.FailedJobsTest/Job.cs
+++ b/Tests/Integration/Fastjobs.FailedJobsTest/Job.cs
@@ -1,0 +1,19 @@
+using FastJobs;
+using Microsoft.Extensions.Logging;
+
+public class FailJob : IBackGroundJob
+{
+    private readonly ILogger<FailJob> _logger;
+
+    public FailJob(ILogger<FailJob> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("[{Thread}] This Job Is Expected to Fail Continously ", Thread.CurrentThread.Name);
+
+        throw new ArgumentException( "Fail test " ); 
+    }
+}

--- a/Tests/Integration/Fastjobs.FailedJobsTest/Test.cs
+++ b/Tests/Integration/Fastjobs.FailedJobsTest/Test.cs
@@ -8,13 +8,13 @@ using Xunit.Abstractions;
 public class ServerCollectionDefinition { }
 
 [Collection("FastJobServerTests")]
-public class AfterActionTest : IClassFixture<AfterActionJobTestFixture>
+public class FailedJobTest : IClassFixture<FailedJobFixtureTest>
 {
-    private readonly AfterActionJobTestFixture _fixture;
+    private readonly FailedJobFixtureTest _fixture;
     private readonly ITestOutputHelper _output;
     private readonly IJobRepository _repo;
 
-    public AfterActionTest(AfterActionJobTestFixture fixture, ITestOutputHelper output)
+    public FailedJobTest(FailedJobFixtureTest fixture, ITestOutputHelper output)
     {
         _fixture = fixture;
         _repo = fixture.Host.Services.GetService<IJobRepository>();
@@ -45,14 +45,13 @@ public class AfterActionTest : IClassFixture<AfterActionJobTestFixture>
         var since = DateTime.UtcNow;
 
         // Act
-        await FastJobServer.EnqueueJob<DeleteAfterActionTestJob>()
-            .AddAfterAction(x => x.WithType<DeleteAfterAction>())
+        await FastJobServer.EnqueueJob<FailJob>()
             .Start();
 
         await WaitUntilAsync(
-            condition: async () => (await _repo.GetAllAsync()).Count,
-            expected: 0,
-            timeout: TimeSpan.FromSeconds(50));
+            condition: () => _repo.CountFailedSinceAsync(since),
+            expected: 1,
+            timeout: TimeSpan.FromSeconds(70));
 
         var allEntries = await _repo.GetAllAsync();
 
@@ -62,8 +61,8 @@ public class AfterActionTest : IClassFixture<AfterActionJobTestFixture>
         }
 
         // Assert
-        var All = await _repo.GetAllAsync();
-        var count = All.Count;
-        Assert.Equal(0, count);
+        var single = allEntries.Where(x => x.StateName == QueueStateTypes.Failed).SingleOrDefault();
+        Assert.NotNull(single);
+        Assert.Equal(single.MaxRetries, single.RetryCount);
     }
 }

--- a/Tests/Integration/Fastjobs.FailedJobsTest/Test.cs
+++ b/Tests/Integration/Fastjobs.FailedJobsTest/Test.cs
@@ -39,7 +39,7 @@ public class FailedJobTest : IClassFixture<FailedJobFixtureTest>
     }
 
     [Fact]
-    public async Task Job_Throwing_TerminateJobException_Should_Be_Deleted_By_AfterAction()
+    public async Task Job_Should_Exhaust_Retries_and_Then_FAIL()
     {
         // Arrange
         var since = DateTime.UtcNow;

--- a/Tests/Integration/Fastjobs.RetryThenSuccedTests/HostFixture.cs
+++ b/Tests/Integration/Fastjobs.RetryThenSuccedTests/HostFixture.cs
@@ -1,0 +1,22 @@
+
+
+using FastJobs;
+using FastJobs.Persistence;
+using HostFixtureProviders;
+using Microsoft.Extensions.DependencyInjection;
+
+public class RetryThenSuccedFixture : FastJobsHostFixtureBase
+{
+    public RetryThenSuccedFixture() : base(new MariaDBFixture()) { }
+
+    protected override void ConfigureFastJobs(IServiceCollection services, string connectionString)
+    {
+        services.AddJobService<RetryThenSucceedJob>();
+        services.AddFastJobs(o => { o.WorkerCount = 1; o.Jitter = TimeSpan.FromSeconds(2); o.JobRetryDelayBase = TimeSpan.FromSeconds(5); },
+            new FastJobMysqlDependencies(x =>
+            {
+                x.ConnectionString = connectionString;
+                x.SchemaName = "FastjobsDB";
+            }));
+    }
+}

--- a/Tests/Integration/Fastjobs.RetryThenSuccedTests/Job.cs
+++ b/Tests/Integration/Fastjobs.RetryThenSuccedTests/Job.cs
@@ -1,0 +1,29 @@
+
+using FastJobs;
+using Microsoft.Extensions.Logging;
+
+public class RetryThenSucceedJob : IBackGroundJob
+{
+    private readonly ILogger<RetryThenSucceedJob> _logger;
+    private readonly JobContext context;
+
+    public RetryThenSucceedJob(ILogger<RetryThenSucceedJob> logger, IJobContext jobContext)
+    {
+        context = (JobContext)jobContext;
+        _logger = logger;
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("[{Thread}] Retry-then-succeed test  ", Thread.CurrentThread.Name);
+
+        if(context.CurrentJob.RetryCount < 1)
+        {
+            throw new ArgumentException( "Fail On First trial " ); 
+        }
+        else
+        {
+            _logger.LogInformation("[{Thread}] Complete On Second Try  ", Thread.CurrentThread.Name);
+        }
+    }
+}

--- a/Tests/Integration/Fastjobs.RetryThenSuccedTests/RetryThenSucceed.csproj
+++ b/Tests/Integration/Fastjobs.RetryThenSuccedTests/RetryThenSucceed.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DBHostFixtureProviders\DBHostFixtureProvider.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Integration/Fastjobs.RetryThenSuccedTests/Test.cs
+++ b/Tests/Integration/Fastjobs.RetryThenSuccedTests/Test.cs
@@ -1,0 +1,72 @@
+using FastJobs;
+using FastJobs.AfterActions;
+using FastJobs.Dashboard.Models;
+using FastJobs.Persistence;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+[CollectionDefinition("FastJobServerTests")]
+public class ServerCollectionDefinition { }
+
+
+[Collection("FastJobServerTests")]
+public class RetryThenSucceedTest : IClassFixture<RetryThenSuccedFixture>
+{
+    private readonly RetryThenSuccedFixture _fixture;
+    private readonly ITestOutputHelper _output;
+    private readonly IJobRepository _repo;
+
+    public RetryThenSucceedTest(RetryThenSuccedFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _repo = fixture.Host.Services.GetRequiredService<IJobRepository>();
+        _output = output;
+    }
+
+    private static async Task WaitUntilAsync(
+        Func<Task<int>> condition,
+        int expected,
+        TimeSpan timeout)
+    {
+        var start = DateTime.UtcNow;
+        var actual = 0;
+        while (DateTime.UtcNow - start < timeout)
+        {
+            actual = await condition();
+            if (actual == expected)
+                return;
+
+            await Task.Delay(100); // poll interval
+        }
+    }
+
+    [Fact]
+    public async Task Job_Failing_Once_Should_Retry_And_Then_Succeed()
+    {
+        // Arrange
+        var since = DateTime.UtcNow;
+
+        // Act
+        await FastJobServer.EnqueueJob<RetryThenSucceedJob>()
+            .Start();
+
+        await WaitUntilAsync(
+            condition: () => _repo.CountCompletedSinceAsync(since),
+            expected: 1,
+            timeout: TimeSpan.FromSeconds(70));
+
+        var allEntries = await _repo.GetAllAsync();
+
+        foreach (var e in allEntries)
+        {
+            _output.WriteLine($"Name: {e.TypeName} state: {e.StateName} retryCount: {e.RetryCount}");
+        }
+
+        // Assert
+        var single = allEntries.Where(x => x.StateName == QueueStateTypes.Completed).SingleOrDefault();
+        Assert.NotNull(single);
+
+        // Confirms it actually failed once before succeeding, not that it
+        // just happened to complete on the first attempt.
+        Assert.Equal(1, single.RetryCount);
+    }
+}

--- a/Tests/Integration/TerminateExceptionTest/Job.cs
+++ b/Tests/Integration/TerminateExceptionTest/Job.cs
@@ -7,7 +7,7 @@ public class TerminateExceptionJob : IBackGroundJob
 
     public TerminateExceptionJob(ILogger<TerminateExceptionJob> logger)
     {
-        _logger = logger as ILogger<TerminateExceptionJob> ?? throw new ArgumentNullException(nameof(logger));
+        _logger = logger;
     }
 
     public async Task ExecuteAsync(CancellationToken cancellationToken)
@@ -15,5 +15,7 @@ public class TerminateExceptionJob : IBackGroundJob
         _logger.LogInformation("[{Thread}] Exception Termination Test Started Processing", Thread.CurrentThread.Name);
 
         throw new TerminateJobException ("Test for intentional job Termination by TerminateRetryException ");
+
+        _logger.LogInformation("[{Thread}] Processing Should Never reach this point", Thread.CurrentThread.Name);
     }
 }

--- a/Tests/Integration/TerminateExceptionTest/Test.cs
+++ b/Tests/Integration/TerminateExceptionTest/Test.cs
@@ -56,7 +56,7 @@ public class TerminateExceptionJobTests : IClassFixture<TerminateJobTestFixture>
 
         var allEntries = await _repo.GetAllAsync();
         var failedJob = allEntries
-        .Where(e => e.StateName == QueueStateTypes.Failed) // or whatever enum value marks it failed
+        .Where(e => e.StateName == QueueStateTypes.Failed) 
         .SingleOrDefault();
 
         foreach (var e in allEntries)

--- a/src/FastJobs.Core/Data/Dtos/FastJobsOptions.cs
+++ b/src/FastJobs.Core/Data/Dtos/FastJobsOptions.cs
@@ -4,6 +4,7 @@ public class FastJobsOptions
     public int WorkerCount {get; set; } = 1;
     public TimeSpan DefaultJobExpiration {get; set; } = TimeSpan.FromHours(24);
 
+    //Exponential Backoff for Retry logic 
     public TimeSpan JobRetryDelayBase {get; set; } = TimeSpan.FromSeconds(10);
     public TimeSpan MaxJobRetryDelay {get; set; } = TimeSpan.FromSeconds(300);
     public TimeSpan Jitter {get; set; } = TimeSpan.FromSeconds(5);

--- a/src/FastJobs.Core/Services/Processing/Worker.cs
+++ b/src/FastJobs.Core/Services/Processing/Worker.cs
@@ -55,7 +55,7 @@ public partial class Worker
         {
             while (!_shutdownToken.IsCancellationRequested)
             {
-                Tuple<Queue, SessionDatabaseLock>? JobDetails = null;
+                Tuple<Queue, SessionDatabaseLock>? JobQueueDetails = null;
 
   
                 if (await _QueueProcessor.AllQueuesEmpty(_shutdownToken))
@@ -74,7 +74,7 @@ public partial class Worker
                     if (await _QueueProcessor.AllQueuesEmpty(_shutdownToken))
                         continue;
 
-                    JobDetails = await _QueueProcessor.Dequeue(_shutdownToken);
+                    JobQueueDetails = await _QueueProcessor.Dequeue(_shutdownToken);
                 }
                 finally
                 {
@@ -83,14 +83,14 @@ public partial class Worker
 
                 using (var Scope = new ScopeManager(serviceScopeFactory))
                 {
-                    if (JobDetails == null)
+                    if (JobQueueDetails == null)
                         continue;
 
                     await WakeWorker(workerRecord);
 
                     //RESOLVE JOB DETAILS 
                     IJobRepository JobRepo = Scope.Resolve<IJobRepository>();
-                    Job job = await JobRepo.GetByIdAsync(JobDetails.Item1.JobId);
+                    Job job = await JobRepo.GetByIdAsync(JobQueueDetails.Item1.JobId);
 
                     // If the job has expired by the time we got it, skip processing
                     if (job.ExpiresAt.HasValue && DateTime.UtcNow >= job.ExpiresAt.Value)
@@ -145,8 +145,17 @@ public partial class Worker
                     }
                     catch (Exception ex)
                     {
-                         _logger.LogError(ex, "Job #{JobID} of type {DeclaringTypeName} Beginning Retry {RetryCOunt}  ", job.Id, job.MethodDeclaringTypeName, job.RetryCount + 1);
-                        await _QueueProcessor.RequeueJobAsync(JobDetails.Item1, JobDetails.Item2, Scope, ex.Message);
+                        //if Job has Exceeded its retry Limit Fail the job
+                        if( !(job.RetryCount >= 3))
+                        {
+                            _logger.LogError(ex, "Job #{JobID} of type {DeclaringTypeName} Beginning Retry {RetryCOunt}  ", job.Id, job.MethodDeclaringTypeName, job.RetryCount + 1);
+                            await _QueueProcessor.RequeueJobAsync(JobQueueDetails.Item1, JobQueueDetails.Item2, Scope, ex.Message);
+                        }
+                        else
+                        {
+                            await _QueueProcessor.FailJobAsync(job, ex.Message);
+                        }
+
                     }
                     finally
                     {
@@ -161,8 +170,23 @@ public partial class Worker
                         }
                     }
 
+                    try
+                    {
+                        if(jobSucceeded)
+                        {
+                           await _QueueProcessor.CompleteJobAsync(JobQueueDetails.Item1, JobQueueDetails.Item2);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        // Log but don't requeue — job work is done, only cleanup failed
+                        _logger.LogError(ex, "Job #{JobID} of type {DeclaringTypeName} Failed State Update After Completion ",
+                            job.Id, 
+                            job.MethodDeclaringTypeName                             );
+                    }
+
             
-                    await RescheduleOrRunAfterAction(JobDetails, job, Scope, jobSucceeded);
+                    await RescheduleOrRunAfterAction(job, Scope, jobSucceeded);
                     jobContext.SetJob(null);
 
                 }
@@ -200,20 +224,9 @@ public partial class Worker
         }
     }
 
-    internal async Task RescheduleOrRunAfterAction(Tuple<Queue, SessionDatabaseLock> JobDetails, Job job, ScopeManager Scope, bool JobSuceeded)
+    internal async Task RescheduleOrRunAfterAction(Job job, ScopeManager Scope, bool JobSuceeded)
     {
-        try
-        {
-            await _QueueProcessor.CompleteJobAsync(JobDetails.Item1, JobDetails.Item2);
-        }
-        catch (Exception ex)
-        {
-            // Log but don't requeue — job work is done, only cleanup failed
-            _logger.LogError(ex, "Job #{JobID} of type {DeclaringTypeName} Failed State Update After Completion ",
-                job.Id, 
-                job.MethodDeclaringTypeName                             );
-        }
-
+        //Reschedule Recurring Job Types
         if (job.JobType == JobTypes.Recurring )
          {  
             bool RetriesExhausted = job.RetryCount >= job.MaxRetries;


### PR DESCRIPTION
- Stop RescheduleOrRunAfterAction() from overwriting terminated jobs' Failed state back to Completed
- Call QueueProcessor.FailJobAsync() when a job exhausts its retries, so it correctly transitions to Failed instead of staying unresolved