### PR TITLE
Fix/recurring scheduler

### DIFF
--- a/ADRS/CompletionTrackingRecurringJobs.md
+++ b/ADRS/CompletionTrackingRecurringJobs.md
@@ -1,0 +1,27 @@
+# ADR: Aggregate Completion Tracking for Recurring Job Instances
+
+## Status
+Proposed
+
+## Context
+Recurring jobs currently track state per-instance only (`Completed`, `Failed`, etc.). 
+Series-level state (`Scheduled`, `Expired`) reflects scheduler lifecycle, not execution outcomes.
+There is no way to answer "how did this recurring series perform overall?" 
+(e.g., N succeeded / N failed) without querying and aggregating all instance history manually.
+
+## Decision
+Not yet decided. Options to evaluate:
+
+1. Add a separate aggregate/summary record per `RecurringJob` id, tallying instance outcomes 
+   (success/failure counts), updated on each instance completion.
+2. Compute aggregation on-demand via a query/view over state history instead of maintaining a stored summary.
+3. Leave as-is; rely on state history + reporting layer for aggregation.
+
+## Consequences
+- Aggregate tracking must stay decoupled from series lifecycle state (`Expired`/`Scheduled`) 
+  per prior decision that expiry ≠ completion outcome.
+- Stored aggregate (Option 1) adds write overhead per instance; on-demand query (Option 2) adds read cost.
+
+## Open Questions
+- Is aggregate state needed in real time, or is reporting-time aggregation sufficient?
+- Where should this live: `RecurringJob` entity, separate table, or reporting layer?

--- a/src/FastJobs.Core/Services/Helpers/SchedulingHelper.cs
+++ b/src/FastJobs.Core/Services/Helpers/SchedulingHelper.cs
@@ -1,0 +1,47 @@
+using FastJobs.Persistence;
+
+namespace FastJobs;
+
+internal static class RecurringJobScheduling
+{
+    public static async Task<bool> ScheduleNextOccurrenceAsync(
+        RecurringJob recurringJob,
+        ScopeManager scope,
+        CancellationToken ct)
+    {
+        var jobRepository = scope.Resolve<IJobRepository>();
+        var recurringJobRepository = scope.Resolve<IRecurringJobRepository>();
+        var scheduledJobRepository = scope.Resolve<IScheduledJobRepository>();
+        var stateHelper = new StateHelpers(jobRepository, scope.Resolve<IStateHistoryRepository>());
+
+        var job = await jobRepository.GetByIdAsync(recurringJob.JobId);
+        if (job == null) return false;
+
+        if (job.ExpiresAt.HasValue && DateTime.UtcNow >= job.ExpiresAt.Value)
+            return false;
+
+        if (!recurringJob.IsConcurrent && recurringJob.ExecutingInstances > 0)
+            return false;
+
+        var nextRun = recurringJob.ComputeNextRun(DateTime.UtcNow);
+        if (nextRun == null) return false;
+
+        var scheduledJobInfo = new ScheduledJobInfo
+        {
+            JobId = recurringJob.JobId, // underlying job, not the recurring job's own id
+            ScheduledTo = nextRun.Value
+        };
+
+        var scheduledId = await scheduledJobRepository.InsertAsync(scheduledJobInfo, ct);
+
+        recurringJob.NextScheduledID = scheduledId;
+        recurringJob.NextScheduledTime = nextRun.Value;
+        await recurringJobRepository.UpdateByIdAsync(recurringJob, ct);
+
+        await stateHelper.UpdateJobStateAsync(
+            recurringJob.id, QueueStateTypes.Scheduled,
+            $"Recurring job #{recurringJob.id} rescheduled for {nextRun:O}", "", ct);
+
+        return true;
+    }
+}

--- a/src/FastJobs.Core/Services/Processing/OrphanedRecurringJobSweeper.cs
+++ b/src/FastJobs.Core/Services/Processing/OrphanedRecurringJobSweeper.cs
@@ -5,22 +5,22 @@ namespace FastJobs;
 using FastJobs.Persistence;
 using Microsoft.Extensions.Logging;
 
-internal class RecurringScheduler
+internal class OrphanedRecurringJobSweeper 
 {
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly SemaphoreSlim _signal = new SemaphoreSlim(0, 1);
     private readonly TimeSpan _idleWait;
     private readonly Action _notifyScheduledJobAdded;
 
-    private readonly ILogger<RecurringScheduler> _logger;
+    private readonly ILogger<OrphanedRecurringJobSweeper > _logger;
 
-    public RecurringScheduler(IServiceScopeFactory scopeFactory, Action notifyScheduledJobAdded)
+    public OrphanedRecurringJobSweeper (IServiceScopeFactory scopeFactory, Action notifyScheduledJobAdded)
     {
         _scopeFactory = scopeFactory;
         _notifyScheduledJobAdded = notifyScheduledJobAdded;
 
         using var scope = new ScopeManager(scopeFactory);
-        _logger = scope.Resolve<ILogger<RecurringScheduler>>();
+        _logger = scope.Resolve<ILogger<OrphanedRecurringJobSweeper >>();
         var options = scope.Resolve<FastJobsOptions>();
         _idleWait = options.IdleWaitPeriod;
     }

--- a/src/FastJobs.Core/Services/Processing/ProcessingServer.cs
+++ b/src/FastJobs.Core/Services/Processing/ProcessingServer.cs
@@ -8,11 +8,11 @@ internal class ProcessingServer
     private WorkerManager? _workerManager;
 
     private Scheduler? SchedulerProcess; 
-    private RecurringScheduler? RecurringSchedulerProcess;
+    private OrphanedRecurringJobSweeper ? RecurringSchedulerProcess;
     private CancellationTokenSource _shutdownCts;
 
     private Task SchedulerTask;
-    private Task RecurringSchedulerTask;
+    private Task OrphanedRecurringJobSweeperTask;
     
     private int WorkerCount; 
 
@@ -22,7 +22,7 @@ internal class ProcessingServer
         _shutdownCts = shutdownCts;
         WorkerCount = options.WorkerCount;
         SchedulerProcess = new Scheduler(serviceScopeFactory);
-        RecurringSchedulerProcess = new RecurringScheduler(serviceScopeFactory, NotifyScheduledJobAdded);
+        RecurringSchedulerProcess = new OrphanedRecurringJobSweeper (serviceScopeFactory, NotifyScheduledJobAdded);
     }
 
     public void StartProcessingJobs()
@@ -36,7 +36,7 @@ internal class ProcessingServer
             await SchedulerProcess.StartScheduler(_shutdownCts.Token);
         });
 
-       RecurringSchedulerTask = Task.Run(async () => {
+       OrphanedRecurringJobSweeperTask = Task.Run(async () => {
             await RecurringSchedulerProcess.StartAsync(_shutdownCts.Token);
        });
     }

--- a/src/FastJobs.Core/Services/Processing/RecurringScheduler.cs
+++ b/src/FastJobs.Core/Services/Processing/RecurringScheduler.cs
@@ -56,33 +56,18 @@ internal class RecurringScheduler
     {
         using var scope = new ScopeManager(_scopeFactory);
         var recurringRepo = scope.Resolve<IRecurringJobRepository>();
-        var scheduledRepo = scope.Resolve<IScheduledJobRepository>();
 
-        // Query for orphaned recurring jobs
         var orphanedJobs = await recurringRepo.GetOrphanedRecurringJobsAsync(ct);
+
+        var anyScheduled = false;
         foreach (var recurringJob in orphanedJobs)
         {
-            // Compute next run from now
-            var nextRun = recurringJob.ComputeNextRun(DateTime.UtcNow);
-            if (nextRun == null) continue;
-
-            var scheduledJobInfo = new ScheduledJobInfo
-            {
-                JobId = recurringJob.JobId,
-                ScheduledTo = nextRun.Value
-            };
-
-            var scheduledId = await scheduledRepo.InsertAsync(scheduledJobInfo, ct);
-            recurringJob.NextScheduledID = scheduledId;
-            recurringJob.NextScheduledTime = nextRun.Value;
-
-            await recurringRepo.UpdateByIdAsync(recurringJob, ct);
+            if (await RecurringJobScheduling.ScheduleNextOccurrenceAsync(recurringJob, scope, ct))
+                anyScheduled = true;
         }
 
-        if (orphanedJobs.Any())
-        {
+        if (anyScheduled)
             _notifyScheduledJobAdded();
-        }
     }
 
   

--- a/src/FastJobs.Core/Services/Processing/Worker.cs
+++ b/src/FastJobs.Core/Services/Processing/Worker.cs
@@ -232,7 +232,7 @@ public partial class Worker
             bool RetriesExhausted = job.RetryCount >= job.MaxRetries;
             if(RetriesExhausted || JobSuceeded)
             {
-                await RescheduleRecurringJobAsync(job.Id ?? 0, Scope);
+                await RescheduleRecurringJobAsync(job.Id ?? 0, Scope, _shutdownToken);
             }
          }
 
@@ -347,48 +347,16 @@ public partial class Worker
 }
 
 
-    private async Task RescheduleRecurringJobAsync(long RecurringjobId, ScopeManager scope)
+    private async Task RescheduleRecurringJobAsync(long RecurringjobId, ScopeManager scope, CancellationToken ct)
     {
         var recurringJobRepository = scope.Resolve<IRecurringJobRepository>();
-        var scheduledJobRepository = scope.Resolve<IScheduledJobRepository>();
         var processingServer = scope.Resolve<ProcessingServer>();
-        var jobRepository = scope.Resolve<IJobRepository>();
-        var stateHelper = new StateHelpers(jobRepository, scope.Resolve<IStateHistoryRepository>());
 
         var recurringJob = await recurringJobRepository.GetByIdAsync(RecurringjobId);
         if (recurringJob == null) return;
 
-        // Fetch the job to check expiry from Jobs table
-        var job = await jobRepository.GetByIdAsync(recurringJob.JobId);
-        if (job == null) return;
-
-        // If the job has expired, do not reschedule
-        if (job.ExpiresAt.HasValue && DateTime.UtcNow >= job.ExpiresAt.Value)
-            return; 
-
-        // Check concurrency if not concurrent
-        if (!recurringJob.IsConcurrent && recurringJob.ExecutingInstances > 0)
-            return; // Skip this cycle
-
-        // Compute next run
-        var nextRun = recurringJob.ComputeNextRun(DateTime.UtcNow);
-        if (nextRun == null) return; // No more occurrences
-
-        // Insert next scheduled job
-        var scheduledJob = new ScheduledJobInfo
-        {
-            JobId = recurringJob.JobId,
-            ScheduledTo = nextRun.Value
-        };
-        var scheduledId = await scheduledJobRepository.InsertAsync(scheduledJob);
-
-        // Update recurring job
-        recurringJob.NextScheduledID = scheduledId;
-        recurringJob.NextScheduledTime = nextRun.Value;
-        await recurringJobRepository.UpdateByIdAsync(recurringJob);
-
-        await stateHelper.UpdateJobStateAsync(recurringJob.JobId, QueueStateTypes.Scheduled, $"Recurring job #{recurringJob.id} rescheduled for {nextRun:O}", "", CancellationToken.None);
-
-        processingServer.NotifyScheduledJobAdded();
+        var scheduled = await RecurringJobScheduling.ScheduleNextOccurrenceAsync(recurringJob, scope, ct);
+        if (scheduled)
+            processingServer.NotifyScheduledJobAdded();
     }
 }

--- a/src/FastJobs.Core/Services/Processing/Worker.cs
+++ b/src/FastJobs.Core/Services/Processing/Worker.cs
@@ -377,7 +377,7 @@ public partial class Worker
         // Insert next scheduled job
         var scheduledJob = new ScheduledJobInfo
         {
-            JobId = RecurringjobId,
+            JobId = recurringJob.JobId,
             ScheduledTo = nextRun.Value
         };
         var scheduledId = await scheduledJobRepository.InsertAsync(scheduledJob);
@@ -387,7 +387,7 @@ public partial class Worker
         recurringJob.NextScheduledTime = nextRun.Value;
         await recurringJobRepository.UpdateByIdAsync(recurringJob);
 
-        await stateHelper.UpdateJobStateAsync(RecurringjobId, QueueStateTypes.Scheduled, $"Recurring job #{recurringJob.id} rescheduled for {nextRun:O}", "", CancellationToken.None);
+        await stateHelper.UpdateJobStateAsync(recurringJob.JobId, QueueStateTypes.Scheduled, $"Recurring job #{recurringJob.id} rescheduled for {nextRun:O}", "", CancellationToken.None);
 
         processingServer.NotifyScheduledJobAdded();
     }


### PR DESCRIPTION
## PR

**Extract `RecurringJobScheduling.ScheduleNextOccurrenceAsync` — unify worker and recovery-sweep rescheduling**

Both `RescheduleRecurringJobAsync` and `RunRecoverySweepAsync` reimplemented the same logic and had drifted. This PR moves both onto one shared helper and fixes what had diverged:

- `ScheduledJobInfo.JobId` bug — worker was writing the recurring job's id instead of the underlying job's id.
- Sweep ignored `Job.ExpiresAt` — expired recurring jobs could be resurrected.
- Sweep skipped the concurrency guard.
- Sweep never wrote state history.
- Sweep notified on `orphanedJobs.Any()` even when nothing was actually scheduled — now only notifies if `ScheduleNextOccurrenceAsync` returned `true` for at least one job.

No intended behavior change to the worker path beyond the `JobId` fix.

---

## Tests needed

- **`ScheduleNextOccurrenceAsync`** — unit tests for each early-return branch (expired, non-concurrent+busy, no next run) plus the happy path, asserting `ScheduledJobInfo.JobId == recurringJob.JobId` (regression guard) and that state history gets written.
- **Recurring job after-actions** — no current coverage for post-execution behavior; needs a suite covering: next occurrence scheduled correctly, expired job stops the chain, non-concurrent job skips a cycle while busy, notify fires only when scheduled.
- **Sweep** — orphan + expired → not re-seeded (regression test for the main bug); orphan + busy non-concurrent → not re-seeded; healthy orphan → re-seeded with state history; mixed batch → notify fires exactly once.
