### PR TITLE
Fix/misfire detector

### DIFF
--- a/src/FastJobs.Core/Services/Processing/QueueProcessor.cs
+++ b/src/FastJobs.Core/Services/Processing/QueueProcessor.cs
@@ -147,17 +147,26 @@ internal class QueueProcessor
 
 
 
-    internal async Task FailJobAsync(Job job, string ExceptionMessage)
+    internal async Task FailJobAsync(Job job, Queue QueueEntry, SessionDatabaseLock QueueLock, string ExceptionMessage)
     {
         //NOTE: Intentionally no CancellationToken — compensating operation must complete
         // Update job state with atomic state history creation and rollback support
+        try {
         await _stateHelpers.UpdateJobStateAsync(
             job.Id ?? 0,
             QueueStateTypes.Failed,
             $"Job #{job.Id} of Type {job.MethodDeclaringTypeName} Has Failed As Many As {job.MaxRetries} Times Or Was Intentionally Terminated",
             data: ExceptionMessage);
 
-        //Might need to remove Dequeues
+        
+            await _queueRepo.RemoveAsync(QueueEntry.Id);
+        }
+        finally
+        {
+            await QueueLock.ReleaseLockAsync();
+            QueueLock.Dispose();
+        }
+            
     }
 
     public async Task RequeueJobAsync(Queue JobQueueEntry, SessionDatabaseLock QueueLock, ScopeManager Scope,  string ExceptionMessage = "")
@@ -176,7 +185,7 @@ internal class QueueProcessor
 
             if(Job.RetryCount >= Job.MaxRetries)
             {
-                await FailJobAsync(Job, ExceptionMessage);
+                await FailJobAsync(Job, JobQueueEntry, QueueLock,  ExceptionMessage);
                 return;
             }
 

--- a/src/FastJobs.Core/Services/Processing/QueueProcessor.cs
+++ b/src/FastJobs.Core/Services/Processing/QueueProcessor.cs
@@ -99,6 +99,28 @@ internal class QueueProcessor
         return null;
     }
 
+    public async Task ExpireJobAsync(Queue JobQueueEntry, SessionDatabaseLock QueueLock)
+    {
+        //NOTE: Intentionally no CancellationToken — finalisation operation must complete to avoid orphaned locks
+        try
+        {
+            
+            // Update job state with atomic state history creation and rollback support
+            await _stateHelpers.UpdateJobStateAsync(
+                JobQueueEntry.JobId,
+                QueueStateTypes.Expired,
+                 $"Job #{JobQueueEntry.JobId} Has Expired",
+                data: "");
+
+            await _queueRepo.RemoveAsync(JobQueueEntry.Id);
+        }
+        finally
+        {
+            await QueueLock.ReleaseLockAsync();
+            QueueLock.Dispose();
+        }
+                        
+    }
 
     public async Task CompleteJobAsync(Queue JobQueueEntry, SessionDatabaseLock QueueLock)
     {
@@ -122,6 +144,9 @@ internal class QueueProcessor
         }
     }
 
+
+
+
     internal async Task FailJobAsync(Job job, string ExceptionMessage)
     {
         //NOTE: Intentionally no CancellationToken — compensating operation must complete
@@ -131,6 +156,8 @@ internal class QueueProcessor
             QueueStateTypes.Failed,
             $"Job #{job.Id} of Type {job.MethodDeclaringTypeName} Has Failed As Many As {job.MaxRetries} Times Or Was Intentionally Terminated",
             data: ExceptionMessage);
+
+        //Might need to remove Dequeues
     }
 
     public async Task RequeueJobAsync(Queue JobQueueEntry, SessionDatabaseLock QueueLock, ScopeManager Scope,  string ExceptionMessage = "")

--- a/src/FastJobs.Core/Services/Processing/Worker.cs
+++ b/src/FastJobs.Core/Services/Processing/Worker.cs
@@ -145,7 +145,7 @@ public partial class Worker
                     }
                     catch (TerminateJobException ex)
                     {
-                        await _QueueProcessor.FailJobAsync(job, ex.Message);
+                        await _QueueProcessor.FailJobAsync(job, JobQueueDetails.Item1, JobQueueDetails.Item2, ex.Message);
                     }
                     catch (Exception ex)
                     {
@@ -157,7 +157,7 @@ public partial class Worker
                         }
                         else
                         {
-                            await _QueueProcessor.FailJobAsync(job, ex.Message);
+                            await _QueueProcessor.FailJobAsync(job, JobQueueDetails.Item1, JobQueueDetails.Item2, ex.Message);
                         }
 
                     }

--- a/src/FastJobs.Core/Services/Processing/Worker.cs
+++ b/src/FastJobs.Core/Services/Processing/Worker.cs
@@ -92,9 +92,15 @@ public partial class Worker
                     IJobRepository JobRepo = Scope.Resolve<IJobRepository>();
                     Job job = await JobRepo.GetByIdAsync(JobQueueDetails.Item1.JobId);
 
-                    // If the job has expired by the time we got it, skip processing
+                    // If the job has expired by the time we got it, skip processing And Change the Jobs State 
                     if (job.ExpiresAt.HasValue && DateTime.UtcNow >= job.ExpiresAt.Value)
+                    {
+                        StateHelpers StateHelper = new StateHelpers(JobRepo, Scope.Resolve<IStateHistoryRepository>());
+                        await StateHelper.UpdateJobStateAsync(job.Id ?? 0, QueueStateTypes.Expired, $"Job #{job.Id} of Type {job.MethodDeclaringTypeName} is Expired", "", _shutdownToken);
+
                         continue;
+                    }
+                        
 
                     var ResolvedJob = JobResolver.ResolveJob(job, Scope);
 

--- a/src/FastJobs.Core/Services/Processing/Worker.cs
+++ b/src/FastJobs.Core/Services/Processing/Worker.cs
@@ -95,9 +95,7 @@ public partial class Worker
                     // If the job has expired by the time we got it, skip processing And Change the Jobs State 
                     if (job.ExpiresAt.HasValue && DateTime.UtcNow >= job.ExpiresAt.Value)
                     {
-                        StateHelpers StateHelper = new StateHelpers(JobRepo, Scope.Resolve<IStateHistoryRepository>());
-                        await StateHelper.UpdateJobStateAsync(job.Id ?? 0, QueueStateTypes.Expired, $"Job #{job.Id} of Type {job.MethodDeclaringTypeName} is Expired", "", _shutdownToken);
-
+                        await _QueueProcessor.ExpireJobAsync(JobQueueDetails.Item1, JobQueueDetails.Item2);
                         continue;
                     }
                         

--- a/src/FastJobs.Persistence/Data/JobQueueState.cs
+++ b/src/FastJobs.Persistence/Data/JobQueueState.cs
@@ -6,6 +6,9 @@ public static class QueueStateTypes
     public static string Dequeued = "Dequeued";
     public static string Processing = "Processing";
     public static string Completed = "Completed";
+
+    //NEW STATE TYPE
+    public static string Expired = "Expired";
     public static string Failed = "Failed";
 }
 


### PR DESCRIPTION
fix: Added Expired State So Jobs dont stay in a stale state

fix: Used ExpireJobAsync() to Ensure Stale queueEntry is Deleted and Session-lock for that resource is released

fix: FailJobAsync() Correctly Cleanup Queue and Release resource lock